### PR TITLE
Implement "Export to Labeling..." function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,27 +15,24 @@
 
 	<name>SAM network inside Fiji</name>
 	<description>A Fiji plugin for interactive segmentation using the SAM network</description>
-	<url>TBA</url>
+	<url>https://github.com/segment-anything-models-java/SAMJ-IJ</url>
 	<inceptionYear>2024</inceptionYear>
 	<organization>
-		<name>null</name>
-		<url>null</url>
+		<name>SAMJ</name>
+		<url>https://github.com/segment-anything-models-java</url>
 	</organization>
 	<licenses>
-		<license> <!-- change later to BSD-2...? -->
-			<name>GNU General Public License v2+</name>
-			<url>https://www.gnu.org/licenses/gpl.html</url>
+		<license>
+			<name>Apache Software License, Version 2.0</name>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
 			<distribution>repo</distribution>
 		</license>
 	</licenses>
 
-
-	<!-- TBA !!! -->
 	<developers>
 		<developer>
 			<id>carlosuc3m</id>
-			<name>carlos garcia</name>
-			<url>null</url>
+			<name>Carlos Garcia</name>
 			<roles>
 				<role>developer</role>
 			</roles>
@@ -43,44 +40,45 @@
 	</developers>
 	<contributors>
 		<contributor>
-			<name>carlos garcia</name>
-			<url>null</url>
-			<roles><role>developer</role></roles>
-			<properties><id>carlosuc3m</id></properties>
+			<name>Curtis Rueden</name>
+			<url>https://imagej.net/people/ctrueden</url>
+			<properties><id>ctrueden</id></properties>
 		</contributor>
 	</contributors>
 
 	<mailingLists>
 		<mailingList>
 			<name>Image.sc Forum</name>
-			<archive>https://forum.image.sc/tag/fiji</archive>
+			<archive>https://forum.image.sc/tag/samj</archive>
 		</mailingList>
 	</mailingLists>
 
-	<!-- TBA !!! -->
 	<scm>
-		<connection>scm:git:https://github.com/fiji/Fiji_Plugins</connection>
-		<developerConnection>scm:git:git@github.com:fiji/Fiji_Plugins</developerConnection>
+		<connection>scm:git:https://github.com/segment-anything-models-java/SAMJ-IJ</connection>
+		<developerConnection>scm:git:git@github.com:segment-anything-models-java/SAMJ-IJ</developerConnection>
 		<tag>HEAD</tag>
-		<url>https://github.com/fiji/Fiji_Plugins</url>
+		<url>https://github.com/segment-anything-models-java/SAMJ-IJ</url>
 	</scm>
 	<issueManagement>
 		<system>GitHub Issues</system>
-		<url>https://github.com/fiji/Fiji_Plugins/issues</url>
+		<url>https://github.com/segment-anything-models-java/SAMJ-IJ/issues</url>
 	</issueManagement>
 	<ciManagement>
 		<system>GitHub Actions</system>
-		<url>https://github.com/fiji/Fiji_Plugins/actions</url>
+		<url>https://github.com/segment-anything-models-java/SAMJ-IJ/actions</url>
 	</ciManagement>
 
 	<properties>
 		<package-name>ai.nets.samj</package-name>
-		<license.licenseName>gpl_v2</license.licenseName>
-		<license.copyrightOwners>Fiji developers.</license.copyrightOwners>
-		<license.projectName>Fiji distribution of ImageJ for the life sciences.</license.projectName>
+		<license.licenseName>apache_v2</license.licenseName>
+		<license.copyrightOwners>SAMJ developers.</license.copyrightOwners>
+		<license.projectName>Plugin to help image annotation with SAM-based Deep Learning models</license.projectName>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
+
+		<!-- FIXME: use release version of samj for reproducible builds. -->
+		<samj.version>0.0.1-SNAPSHOT</samj.version>
 	</properties>
 
 	<repositories>
@@ -98,7 +96,7 @@
 		<dependency>
 			<groupId>ai.nets</groupId>
 			<artifactId>samj</artifactId>
-			<version>0.0.1-SNAPSHOT</version>
+			<version>${samj.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>

--- a/src/main/java/ai/nets/samj/ij/SAMJ_Annotator.java
+++ b/src/main/java/ai/nets/samj/ij/SAMJ_Annotator.java
@@ -65,34 +65,34 @@ public class SAMJ_Annotator implements PlugIn {
 			
 			// TODO I (Carlos) don't know how to develop in IJ2 Logger guiSublogger = log.subLogger("PromptsResults window");
 			SAMJLogger guilogger = new SAMJLogger() {
-	            @Override
-	            public void info(String text) {System.out.println(text);}
-	            @Override
-	            public void warn(String text) {System.out.println(text);}
-	            @Override
-	            public void error(String text) {System.out.println(text);}
-	        };
+				@Override
+				public void info(String text) {System.out.println(text);}
+				@Override
+				public void warn(String text) {System.out.println(text);}
+				@Override
+				public void error(String text) {System.out.println(text);}
+			};
 
-	     // TODO I (Carlos) don't know how to develop in IJ2 Logger networkSublogger = log.subLogger("Networks window");
+			// TODO I (Carlos) don't know how to develop in IJ2 Logger networkSublogger = log.subLogger("Networks window");
 			SAMJLogger networkLogger = new SAMJLogger() {
-	            @Override
-	            public void info(String text) {System.out.println("network -- " + text);}
-	            @Override
-	            public void warn(String text) {System.out.println("network -- " + text);}
-	            @Override
-	            public void error(String text) {System.out.println("network -- " + text);}
-	        };
-			
-	        
-	        SwingUtilities.invokeLater(() -> {
-		        SAMJDialog samjDialog = new SAMJDialog( availableModels, new IJSamMethods(), guilogger, networkLogger);
+				@Override
+				public void info(String text) {System.out.println("network -- " + text);}
+				@Override
+				public void warn(String text) {System.out.println("network -- " + text);}
+				@Override
+				public void error(String text) {System.out.println("network -- " + text);}
+			};
+
+
+			SwingUtilities.invokeLater(() -> {
+				SAMJDialog samjDialog = new SAMJDialog( availableModels, new IJSamMethods(), guilogger, networkLogger);
 				//create the GUI adapter between the user inputs/prompts and SAMJ outputs
 				samjDialog.setPromptsProvider((obj) -> {return new IJ1PromptsProvider((ImagePlus) obj, null);});// TODO log.subLogger("PromptsResults window"));});
-				
+
 				JDialog dialog = new JDialog(new JFrame(), "SAMJ Annotator");
 				dialog.addWindowListener(new WindowAdapter() {
 					@Override
-		            public void windowClosing(WindowEvent e) {
+					public void windowClosing(WindowEvent e) {
 						samjDialog.close();
 					}
 				});
@@ -102,7 +102,7 @@ public class SAMJ_Annotator implements PlugIn {
 				dialog.setModal(false);
 				dialog.setVisible(true);
 				GUI.center(dialog);
-	        });
+		});
 		} catch (RuntimeException e) {
 			//TODO log.error("SAMJ error: "+e.getMessage());
 			e.printStackTrace();

--- a/src/main/java/ai/nets/samj/ij/SAMJ_Annotator.java
+++ b/src/main/java/ai/nets/samj/ij/SAMJ_Annotator.java
@@ -51,10 +51,10 @@ public class SAMJ_Annotator implements PlugIn {
 	// TODO I (Carlos) don't know how to develop in IJ2 @Parameter
 	//private LogService logService = new LogService();
 
-	// TODO I (Carlos) don't know how to develop in IJ2 @Override
 	/**
 	 * Run the plugin
 	 */
+	@Override
 	public void run() {
 
 		// TODO I (Carlos) don't know how to develop in IJ2 final Logger log = logService.subLogger("SAMJ");

--- a/src/main/java/ai/nets/samj/ij/ui/IJ1PromptsProvider.java
+++ b/src/main/java/ai/nets/samj/ij/ui/IJ1PromptsProvider.java
@@ -190,14 +190,13 @@ public class IJ1PromptsProvider implements PromptsResultsDisplay, MouseListener,
 	 */
 	public RandomAccessibleInterval<?> giveProcessedSubImage(SAMModel selectedModel) {
 		//the IJ1 image operates always on the full image
-		if (selectedModel.getName().equals(EfficientSAM.FULL_NAME)) {
-			Img<?> image = ImageJFunctions.wrap(activeImage.getType() == 4 ? CompositeConverter.makeComposite(activeImage) : activeImage);
-			return Cast.unchecked(Views.permute(image, 0, 1));
-		} else {
-			Img<?> image = ImageJFunctions.wrap(activeImage.getType() == 4 ? CompositeConverter.makeComposite(activeImage) : activeImage);
-			return Cast.unchecked(Views.permute(image, 0, 1));
-			//return Cast.unchecked(ImageJFunctions.wrap(activeImage));
-		}
+		//if (selectedModel.getName().equals(EfficientSAM.FULL_NAME)) {
+		boolean isColorRGB = activeImage.getType() == ImagePlus.COLOR_RGB;
+		Img<?> image = ImageJFunctions.wrap(isColorRGB ? CompositeConverter.makeComposite(activeImage) : activeImage);
+		return Cast.unchecked(Views.permute(image, 0, 1));
+		//} else {
+		//	return Cast.unchecked(ImageJFunctions.wrap(activeImage));
+		//}
 	}
 
 	@Override

--- a/src/main/java/ai/nets/samj/ij/ui/IJ1PromptsProvider.java
+++ b/src/main/java/ai/nets/samj/ij/ui/IJ1PromptsProvider.java
@@ -154,8 +154,7 @@ public class IJ1PromptsProvider implements PromptsResultsDisplay, MouseListener,
 	 * @param log
 	 * 	logging of the events of the GUI and network
 	 */
-	public IJ1PromptsProvider(final ImagePlus imagePlus,
-	                          final Logger log) {
+	public IJ1PromptsProvider(final ImagePlus imagePlus, final Logger log) {
 		this.promptsToNet = null;
 		this.roiManager = startRoiManager();
 		activeImage = imagePlus;

--- a/src/main/java/ai/nets/samj/ij/ui/IJ1PromptsProvider.java
+++ b/src/main/java/ai/nets/samj/ij/ui/IJ1PromptsProvider.java
@@ -22,6 +22,10 @@ package ai.nets.samj.ij.ui;
 import ij.IJ;
 import ij.ImagePlus;
 import ij.Prefs;
+import ij.process.ByteProcessor;
+import ij.process.FloatProcessor;
+import ij.process.ImageProcessor;
+import ij.process.ShortProcessor;
 import ij.gui.ImageCanvas;
 import ij.gui.ImageWindow;
 import ij.gui.Overlay;
@@ -256,6 +260,42 @@ public class IJ1PromptsProvider implements PromptsResultsDisplay, MouseListener,
 	 */
 	public List<Polygon> getPolygonsFromRoiManager() {
 		return Arrays.stream(roiManager.getRoisAsArray()).map(i -> i.getPolygon()).collect(Collectors.toList());
+	}
+
+	@Override
+	public void exportImageLabeling() {
+		Roi[] rois = this.roiManager.getRoisAsArray();
+		if (rois.length == 0) return; // no ROIs to export
+
+		int width = activeImage.getWidth();
+		int height = activeImage.getHeight();
+
+		ImageProcessor ip = null;
+		if (rois.length <= 255) {
+			ip = new ByteProcessor(width, height);
+		}
+		else if (rois.length <= 65535) {
+			ip = new ShortProcessor(width, height);
+		}
+		else {
+			ip = new FloatProcessor(width, height);
+		}
+
+		ImagePlus imp = new ImagePlus(activeImage.getTitle() + "-labeling", ip);
+
+		int value = 1;
+		for (Roi roi : rois) {
+			ip.setValue(value++);
+			Rectangle bounds = roi.getBounds();
+			for (int y = 0; y < bounds.height; ++y) {
+				for (int x = 0; x < bounds.width; ++x) {
+					if (roi.contains(bounds.x + x, bounds.y + y)) {
+						ip.drawPixel(bounds.x + x, bounds.y + y);
+					}
+				}
+			}
+		}
+		imp.show();
 	}
 
 	@Override

--- a/src/main/resources/plugins.config
+++ b/src/main/resources/plugins.config
@@ -1,1 +1,20 @@
+###
+# #%L
+# Plugin to help image annotation with SAM-based Deep Learning models
+# %%
+# Copyright (C) 2024 SAMJ developers.
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
 Plugins>SAMJ, "SAMJ Annotator", ai.nets.samj.ij.SAMJ_Annotator


### PR DESCRIPTION
This PR implements a new function in the IJ1PromptsProvider, which converts the ROIs currently in the ROI Manager into a new labeling image, with integer indices ascending from 1. It uses the smallest image type into which the numbering will fit: e.g. for <256 ROIs, it will use a uint8 image.

The PR also does some small cleanups to the POM and source code.

Unfortunately, I could not test this code at runtime, because there is a mismatch between the SAMJ codebase and this one:
```
[ERROR] .../SAMJ-IJ/src/main/java/ai/nets/samj/ij/SAMJ_Annotator.java:[57,9] method does not override or implement a method from a supertype
```
This is why I recommend not to use SNAPSHOT couplings for dependencies, but rather always pin to stable release versions, even if they are dev/pre/alpha/beta.

This PR requires segment-anything-models-java/SAMJ#1 on the SAMJ side.